### PR TITLE
fix: creation of nat resource when don't needed

### DIFF
--- a/aws/networking/nat_gateway/main.tf
+++ b/aws/networking/nat_gateway/main.tf
@@ -32,13 +32,13 @@ resource "aws_route" "mod" {
 }
 
 resource "aws_nat_gateway" "mod" {
-    count         = "${var.nat_gateway_count}"
+    count         = "${length(var.private_subnet_ids) > 0 ? var.nat_gateway_count : 0}"
     subnet_id     = "${element(var.public_subnet_ids, count.index)}"
     allocation_id = "${element(aws_eip.mod.*.id, count.index)}"
 }
 
 resource "aws_eip" "mod" {
-    count = "${var.nat_gateway_count}"
+    count = "${length(var.private_subnet_ids) > 0 ? var.nat_gateway_count : 0}"
     vpc   = true
 }
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,8 +1,9 @@
 # TODO
 
-- Split Security Groups rules to avoid inline security groups
-- Apply `Terrafile` to pull modules as dependencies on a `vendor` folder, it will be ideal if this it's done on Go as Terraform was write on Go e.g. http://bensnape.com/2016/01/14/terraform-design-patterns-the-terrafile/
-- Auto-generate ToC on README.md file
-- Add option to control `lifecycle` or the resources by variables
-- Support variable to optionally `lifecycle { ignore_changes = [ "user_data" ] }` so the instance won't be destroy if `user_data` have change
-- Accept different values for `ignore_changes`
+- [ ] Split Security Groups rules to avoid inline security groups
+- [ ] Apply `Terrafile` to pull modules as dependencies on a `vendor` folder, it will be ideal if this it's done on Go as Terraform was write on Go e.g. http://bensnape.com/2016/01/14/terraform-design-patterns-the-terrafile/
+- [ ] Auto-generate ToC on README.md file
+- [ ] Add option to control `lifecycle` or the resources by variables
+- [ ] Support variable to optionally `lifecycle { ignore_changes = [ "user_data" ] }` so the instance won't be destroy if `user_data` have change
+- [ ] Accept different values for `ignore_changes`
+- [ ] Extract `aws_proxy_protocol_policy` from `ELB`


### PR DESCRIPTION
We check for the length of the private_subnet_ids to create NAT resources, this is needed as we can't control the count vault on modules hashicorp/terraform#953 (comment)